### PR TITLE
Renames `image` to `data` in `ImageHolder`, allows passing `ImageHolder` to `remove_from_image` 

### DIFF
--- a/remove_starfield/core.py
+++ b/remove_starfield/core.py
@@ -361,7 +361,7 @@ def _process_file(args):
     swcs = starfield_wcs[ymin:ymax, xmin:xmax]
     
     output = reproject.reproject_adaptive(
-        (image_holder.image, image_holder.wcs), swcs, (ymax-ymin, xmax-xmin),
+        (image_holder.data, image_holder.wcs), swcs, (ymax - ymin, xmax - xmin),
         return_footprint=False, roundtrip_coords=False,
         boundary_mode='strict',
         conserve_flux=True,

--- a/remove_starfield/processor.py
+++ b/remove_starfield/processor.py
@@ -16,7 +16,7 @@ class ImageHolder():
     attributes of `ImageHolder` instances to carry necessary information
     through the load -> preprocess -> postprocess chain.
     """
-    image: np.ndarray
+    data: np.ndarray
     wcs: WCS
 
 

--- a/remove_starfield/starfield.py
+++ b/remove_starfield/starfield.py
@@ -9,6 +9,7 @@ import numpy as np
 import reproject
 
 from . import ImageProcessor, SubtractedImage, utils
+from .processor import ImageHolder
 
 
 @dataclass
@@ -241,7 +242,7 @@ class Starfield:
         return im
     
     def subtract_from_image(self,
-                            file : str,
+                            file: str | ImageHolder,
                             processor: ImageProcessor=ImageProcessor()):
         """Subtracts this starfield from an image
         
@@ -252,7 +253,7 @@ class Starfield:
 
         Parameters
         ----------
-        file : ``str``
+        file : ``str`` or ImageHolder
             The input file from which to remove stars
         processor : `ImageProcessor`, optional
             An `ImageProcessor` to load the file and pre-process the file.
@@ -262,9 +263,15 @@ class Starfield:
         subtracted : `SubtractedImage`
             A container class storing the subtracted image and all inputs
         """
-        image_holder = processor.load_image(file)
+        if isinstance(file, str):
+            image_holder = processor.load_image(file)
+        elif isinstance(file, ImageHolder):
+            image_holder = file
+        else:
+            raise TypeError("Input file must be a str or ImageHolder")
+
         image_holder = processor.preprocess_image(image_holder)
-        input_data = image_holder.image
+        input_data = image_holder.data
         input_wcs = image_holder.wcs
         
         # Project the starfield into the input image's frame

--- a/remove_starfield/starfield.py
+++ b/remove_starfield/starfield.py
@@ -253,7 +253,7 @@ class Starfield:
 
         Parameters
         ----------
-        file : ``str`` or ImageHolder
+        file : ``str`` or ImageHolder or object with data and wcs attrs
             The input file from which to remove stars
         processor : `ImageProcessor`, optional
             An `ImageProcessor` to load the file and pre-process the file.
@@ -265,10 +265,10 @@ class Starfield:
         """
         if isinstance(file, str):
             image_holder = processor.load_image(file)
-        elif isinstance(file, ImageHolder):
+        elif hasattr(file, "wcs") and hasattr(file, "data"):  # it's like an ImageHolder
             image_holder = file
         else:
-            raise TypeError("Input file must be a str or ImageHolder")
+            raise TypeError("Input file must be a str or an object with `data` and `wcs` attrs")
 
         image_holder = processor.preprocess_image(image_holder)
         input_data = image_holder.data

--- a/remove_starfield/tests/test_processor.py
+++ b/remove_starfield/tests/test_processor.py
@@ -3,8 +3,8 @@ from .. import utils
 
 
 def test_Image_Holder():
-    ih = ImageHolder(image='image', wcs='wcs')
-    assert ih.image == 'image'
+    ih = ImageHolder(data='image', wcs='wcs')
+    assert ih.data == 'image'
     assert ih.wcs == 'wcs'
 
 
@@ -29,10 +29,10 @@ def test_ImageProcessor_passthroughs():
     holder2 = processor.preprocess_image(holder)
     assert holder2 is holder
     
-    post_img = processor.postprocess_image(holder.image, holder.wcs, holder)
-    assert post_img is holder.image
+    post_img = processor.postprocess_image(holder.data, holder.wcs, holder)
+    assert post_img is holder.data
     
     post_starfield = processor.postprocess_starfield_estimate(
-        holder.image, holder)
-    assert post_starfield is holder.image
+        holder.data, holder)
+    assert post_starfield is holder.data
     


### PR DESCRIPTION
As we discussed, this renames the internals of `ImageHolder` from `image` to `data`, thus allowing NDCube's to sneakily be passed in.

It also allows for the option of an `ImageHolder` being passed to `starfield.remove_from_image` instead of just a `str`. This aligns more with a PUNCH need in our pipeline. 